### PR TITLE
Add first React components

### DIFF
--- a/LSCS.Api/Controllers/ControllerBase.cs
+++ b/LSCS.Api/Controllers/ControllerBase.cs
@@ -59,7 +59,8 @@ namespace LSCS.Api.Controllers
                     pageNumber,
                     pageSize,
                     totalElements
-                )));   
+                )));
+            response.Headers.Add("Access-Control-Allow-Origin", "*");
         }
 
         private IEnumerable<string> GetLinkElements(int pageNumber, int pageSize, int totalElements)

--- a/LSCS.Models.Tests/ChecklistTests.cs
+++ b/LSCS.Models.Tests/ChecklistTests.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Device.Location;
+using NUnit.Framework;
+using Newtonsoft.Json;
+
+namespace LSCS.Models.Tests
+{
+    [TestFixture]
+    class ChecklistTests
+    {
+        [Test]
+        public void TestJson()
+        {
+            var Checklist = new ChecklistDto {
+                Title = "Test Title",
+                Description = "Some random description",
+                FileNumber = 12345,
+                SurveyLocation = new SurveyLocation {
+                    LandDistrict = new LandDistrictDto {
+                        Name = "The Rocky Mountains",
+                        NtsMap = "I don't know what NtsMap is",
+                        Coordinate = new GeoCoordinate {
+                            Latitude = 48.441271,
+                            Longitude = -123.344066
+                        }
+                    },
+                    Coordinate = new GeoCoordinate {
+                        Latitude = 48.441271,
+                        Longitude = -123.344066
+                    },
+                    Address = new CivicAddress {
+                        AddressLine1 = "123 Fake Street",
+                        AddressLine2 = null,
+                        Building = "Buckingham Palaca",
+                        City = "London",
+                        CountryRegion = "England",
+                        FloorLevel = null,
+                        PostalCode = "123abc",
+                        StateProvince = "Kenya"
+                    }
+                },
+                Items = new List<ChecklistItem>{
+                    new ChecklistItem {
+                        Text = "This is the first item",
+                        Status = ChecklistItemStatus.Answered
+                    },
+                    new ChecklistItem {
+                        Text = "This is the second item",
+                        Status = ChecklistItemStatus.Unanswered
+                    }
+                }
+            };
+
+            Console.WriteLine(JsonConvert.SerializeObject(Checklist));
+        }
+    }
+}

--- a/LSCS.Models.Tests/LSCS.Models.Tests.csproj
+++ b/LSCS.Models.Tests/LSCS.Models.Tests.csproj
@@ -32,6 +32,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.core">
       <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
       <Private>True</Private>
@@ -54,6 +58,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Device" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -64,6 +69,7 @@
     <Compile Include="..\.global\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="ChecklistTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/LSCS.Models.Tests/packages.config
+++ b/LSCS.Models.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/LSCS.Web/Content/Site.css
+++ b/LSCS.Web/Content/Site.css
@@ -16,11 +16,6 @@ textarea {
     max-width: 280px;
 }
 
-.container {
-    width: 500px;
-    clear: both;
-}
-
 .container form {
     display: table;
 }

--- a/LSCS.Web/Global.asax.cs
+++ b/LSCS.Web/Global.asax.cs
@@ -16,9 +16,7 @@ namespace LSCS.Web
 
         private static void RegisterBundles(BundleCollection bundles)
         {
-            bundles.Add(new JsxBundle("~/Scripts/react").Include(
-                "~/Scripts/Templates/*.jsx"
-            ));
+            // Create static asset bundles here
         }
     }
 }

--- a/LSCS.Web/LSCS.Web.csproj
+++ b/LSCS.Web/LSCS.Web.csproj
@@ -154,7 +154,6 @@
     <Content Include="Content\Site.css" />
     <Content Include="fonts\glyphicons-halflings-regular.svg" />
     <Content Include="Global.asax" />
-    <Content Include="readme.txt" />
     <Content Include="Scripts\bootstrap.js" />
     <Content Include="Scripts\bootstrap.min.js" />
     <None Include="Scripts\jquery-1.10.2.intellisense.js" />
@@ -168,7 +167,6 @@
     <Compile Include="..\.global\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="App_Start\BundleConfig.cs" />
     <Compile Include="App_Start\ReactConfig.cs" />
     <Compile Include="Controllers\ChecklistController.cs" />
     <Compile Include="Controllers\LoginController.cs" />

--- a/LSCS.Web/Scripts/Templates/Checklists.jsx
+++ b/LSCS.Web/Scripts/Templates/Checklists.jsx
@@ -3,17 +3,33 @@
         return (
             <tr>
                 <td>{this.props.data.Title}</td>
+                <td>{this.props.data.SurveyLocation.LandDistrict.Name}</td>
                 <td>{this.props.data.Description}</td>
                 <td>{this.props.data.FileNumber}</td>
-                <td>{this.props.data.Location}</td>
             </tr>
         );
     }
 });
 
 var ChecklistList = React.createClass({
+    loadChecklistsFromServer: function() {
+        var xhr = new XMLHttpRequest();
+        xhr.open('get', this.props.url, true);
+        xhr.onload = function() {
+            var data = JSON.parse(xhr.responseText);
+            this.setState({ data: data });
+        }.bind(this);
+        xhr.send();
+    },
+    componentDidMount: function() {
+        this.loadChecklistsFromServer();
+        window.setInterval(this.loadChecklistsFromServer, this.props.pollInterval);
+    },
+        getInitialState: function() {
+        return {data: []};
+    },
     render: function() {
-        var checklistNodes = this.props.data.map(function (checklist) {
+        var checklistNodes = this.state.data.map(function (checklist) {
             return (
                 <Checklist data={checklist} />
             );
@@ -23,9 +39,9 @@ var ChecklistList = React.createClass({
                 <thead>
                     <tr>
                         <th>Title</th>
+                        <th>Location</th>
                         <th>Description</th>
                         <th>File No.</th>
-                        <th>Location</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -36,9 +52,7 @@ var ChecklistList = React.createClass({
     }
 });
 
-var data = [ { Title: "Test Title", Description: "Some stuff in here", FileNumber: 2053, Location: "The Moon" } ]
-
 React.render(
-    <ChecklistList data={data} />,
+    <ChecklistList url="http://localhost:1059/api/checklists" pollInterval={2000} />,
     document.getElementById('checklist-list')
 );

--- a/LSCS.Web/Scripts/Templates/Checklists.jsx
+++ b/LSCS.Web/Scripts/Templates/Checklists.jsx
@@ -19,7 +19,7 @@ var ChecklistList = React.createClass({
             );
         });
         return (
-            <table>
+            <table className="table table-hover">
                 <thead>
                     <tr>
                         <th>Title</th>

--- a/LSCS.Web/Scripts/Templates/Checklists.jsx
+++ b/LSCS.Web/Scripts/Templates/Checklists.jsx
@@ -1,44 +1,44 @@
 ﻿var Checklist = React.createClass({
-	render: function() {
-		return (
-			<tr>
-				<td>{this.props.data.Title}</td>
-				<td>{this.props.data.Description}</td>
-				<td>{this.props.data.FileNumber}</td>
-				<td>{this.props.data.Location}</td>
-			</tr>
-		);
-	}
+    render: function() {
+        return (
+            <tr>
+                <td>{this.props.data.Title}</td>
+                <td>{this.props.data.Description}</td>
+                <td>{this.props.data.FileNumber}</td>
+                <td>{this.props.data.Location}</td>
+            </tr>
+        );
+    }
 });
 
 var ChecklistList = React.createClass({
-	render: function() {
-		var checklistNodes = this.props.data.map(function (checklist) {
-			return (
-				<Checklist data={checklist} />
-			);
-		});
-		return (
-			<table>
-				<thead>
-					<tr>
-						<th>Title</th>
-						<th>Description</th>
-						<th>File No.</th>
-						<th>Location</th>
-					</tr>
-				</thead>
-				<tbody>
-					{checklistNodes}
-				</tbody>
-			</table>
-		);
-	}
+    render: function() {
+        var checklistNodes = this.props.data.map(function (checklist) {
+            return (
+                <Checklist data={checklist} />
+            );
+        });
+        return (
+            <table>
+                <thead>
+                    <tr>
+                        <th>Title</th>
+                        <th>Description</th>
+                        <th>File No.</th>
+                        <th>Location</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {checklistNodes}
+                </tbody>
+            </table>
+        );
+    }
 });
 
 var data = [ { Title: "Test Title", Description: "Some stuff in here", FileNumber: 2053, Location: "The Moon" } ]
 
 React.render(
-	<ChecklistList data={data} />,
-	document.getElementById('checklist-list')
+    <ChecklistList data={data} />,
+    document.getElementById('checklist-list')
 );

--- a/LSCS.Web/Scripts/Templates/Checklists.jsx
+++ b/LSCS.Web/Scripts/Templates/Checklists.jsx
@@ -1,1 +1,44 @@
-﻿// Create JSX templates here
+﻿var Checklist = React.createClass({
+	render: function() {
+		return (
+			<tr>
+				<td>{this.props.data.Title}</td>
+				<td>{this.props.data.Description}</td>
+				<td>{this.props.data.FileNumber}</td>
+				<td>{this.props.data.Location}</td>
+			</tr>
+		);
+	}
+});
+
+var ChecklistList = React.createClass({
+	render: function() {
+		var checklistNodes = this.props.data.map(function (checklist) {
+			return (
+				<Checklist data={checklist} />
+			);
+		});
+		return (
+			<table>
+				<thead>
+					<tr>
+						<th>Title</th>
+						<th>Description</th>
+						<th>File No.</th>
+						<th>Location</th>
+					</tr>
+				</thead>
+				<tbody>
+					{checklistNodes}
+				</tbody>
+			</table>
+		);
+	}
+});
+
+var data = [ { Title: "Test Title", Description: "Some stuff in here", FileNumber: 2053, Location: "The Moon" } ]
+
+React.render(
+	<ChecklistList data={data} />,
+	document.getElementById('checklist-list')
+);

--- a/LSCS.Web/Views/Checklist/Index.cshtml
+++ b/LSCS.Web/Views/Checklist/Index.cshtml
@@ -1,6 +1,12 @@
 ﻿
 @{
     ViewBag.Title = "Checklists";
+
+}
+@section Scripts{
+    <script src="~/Scripts/Templates/Checklists.jsx"></script>
 }
 
 <h2>Checklists</h2>
+
+<div id="checklist-list"></div>

--- a/LSCS.Web/Views/Shared/_Layout.cshtml
+++ b/LSCS.Web/Views/Shared/_Layout.cshtml
@@ -11,7 +11,6 @@
     <script src="~/Scripts/modernizr-2.6.2.js"></script>
     <script src="~/Scripts/jquery-1.10.2.min.js"></script>
     <script src="~/Scripts/bootstrap.min.js"></script>
-    @Scripts.Render("~/bundles/react")
 </head>
 
 <body>
@@ -36,5 +35,8 @@
             <p>&copy; @DateTime.Now.Year - Land Surveyor Checklist System</p>
         </footer>
     </div>
+
+    <script src="http://fb.me/react-0.13.1.js"></script>
+    @RenderSection("Scripts", required: false)
 </body>
 </html>


### PR DESCRIPTION
This adds the components necessary to render the checklists index page.

The main issue right now is that the table doesn't load until React updates for the first time (we wanted to have it at least render the table headings). This is because we need to specify the target container to render the React component into. If we specify the <table> tag as the element to render it into, it removes its children (the <thead> element and all its children) before inserting the <tbody> and containing elements. We should revisit this and see if there is a way to make this work.
